### PR TITLE
Allow menu entries attached to an osmap xml view to be accessed via adding .xml to the path with SEO

### DIFF
--- a/src/site/views/xml/view.xml.php
+++ b/src/site/views/xml/view.xml.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @package   OSMap
+ * @copyright 2007-2014 XMap - Joomla! Vargas - Guillermo Vargas. All rights reserved.
+ * @copyright 2016-2017 Open Source Training, LLC. All rights reserved.
+ * @contact   www.joomlashack.com, help@joomlashack.com
+ * @license   http://www.gnu.org/licenses/gpl.html GNU/GPL
+ */
+
+defined('_JEXEC') or die();
+
+use Alledia\OSMap;
+
+jimport('joomla.application.component.view');
+
+
+class OSMapViewXml extends JViewLegacy
+{
+    /**
+     * @var string
+     */
+    protected $type = null;
+
+    /**
+     * @var \Joomla\Registry\Registry
+     */
+    protected $params = null;
+
+    /**
+     * @var \Joomla\Registry\Registry
+     */
+    protected $osmapParams = null;
+
+    /**
+     * @var Alledia\OSMap\Sitemap\Standard
+     */
+    protected $sitemap = null;
+
+    /**
+     * @param null $tpl
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function display($tpl = null)
+    {
+        $container = OSMap\Factory::getContainer();
+
+        // Help to show a clean XML without other content
+        $container->input->set('tmpl', 'component');
+
+        $id = $container->input->getInt('id');
+
+        $this->type        = OSMap\Helper\General::getSitemapTypeFromInput();
+        $this->params      = JFactory::getApplication()->getParams();
+        $this->osmapParams = JComponentHelper::getParams('com_osmap');
+
+        $this->sitemap = OSMap\Factory::getSitemap($id, $this->type);
+
+        if (!$this->sitemap->isPublished) {
+            throw new Exception(JText::_('COM_OSMAP_MSG_SITEMAP_IS_UNPUBLISHED'));
+        }
+
+        parent::display($tpl);
+
+        // Force to show a clean XML without other content or execution plugins
+        jexit();
+    }
+}

--- a/src/site/views/xml/view.xml.php
+++ b/src/site/views/xml/view.xml.php
@@ -9,61 +9,10 @@
 
 defined('_JEXEC') or die();
 
-use Alledia\OSMap;
 
-jimport('joomla.application.component.view');
-
-
-class OSMapViewXml extends JViewLegacy
-{
-    /**
-     * @var string
-     */
-    protected $type = null;
-
-    /**
-     * @var \Joomla\Registry\Registry
-     */
-    protected $params = null;
-
-    /**
-     * @var \Joomla\Registry\Registry
-     */
-    protected $osmapParams = null;
-
-    /**
-     * @var Alledia\OSMap\Sitemap\Standard
-     */
-    protected $sitemap = null;
-
-    /**
-     * @param null $tpl
-     *
-     * @return void
-     * @throws Exception
-     */
-    public function display($tpl = null)
-    {
-        $container = OSMap\Factory::getContainer();
-
-        // Help to show a clean XML without other content
-        $container->input->set('tmpl', 'component');
-
-        $id = $container->input->getInt('id');
-
-        $this->type        = OSMap\Helper\General::getSitemapTypeFromInput();
-        $this->params      = JFactory::getApplication()->getParams();
-        $this->osmapParams = JComponentHelper::getParams('com_osmap');
-
-        $this->sitemap = OSMap\Factory::getSitemap($id, $this->type);
-
-        if (!$this->sitemap->isPublished) {
-            throw new Exception(JText::_('COM_OSMAP_MSG_SITEMAP_IS_UNPUBLISHED'));
-        }
-
-        parent::display($tpl);
-
-        // Force to show a clean XML without other content or execution plugins
-        jexit();
-    }
-}
+/*
+ * Having a view.xml.php file in views allows to add
+ * a .xml suffix to the alias, if the sitemap is attached to
+ * a menu entry
+ */
+require_once __DIR__ . '/view.html.php';


### PR DESCRIPTION
Currently when creating a joomla menu entry attached to an xml osmap view with e.g. alias sitemap, which would result in having e.g. the URL ```https://mysite.tld/sitemap``` there is no possibility to access the URL by adding a ```.xml``` suffix to the path like https://mysite.tld/sitemap.xml because the view is implicitly only available as ```.html```. Doing so leads to the error message ```view not found [name, type, prefix]: xml, xml, osmapView```.

One possibility is to add the file ```view.xml.php``` to ```components/com_osmap/views/xml``` as a 1 to 1 copy of ```view.html.php```. 
I think having ```.html``` as a suffix does not make much sense, but should be available for backward compatibility.

Allow menu entries attached to an osmap xml view to be accessed by  adding .xml to the path with SEO