### PR TITLE
Decoration buttons XML, HTML, News, Images

### DIFF
--- a/src/admin/views/sitemaps/tmpl/default_previews.php
+++ b/src/admin/views/sitemaps/tmpl/default_previews.php
@@ -36,10 +36,9 @@ foreach ($languages as $language) :
             'link',
             $this->getLink($this->item, 'xml', $langCode),
             JText::_('COM_OSMAP_XML_LINK'),
-            sprintf('target="_blank" title="%s"', JText::_('COM_OSMAP_XML_LINK_TOOLTIP', true))
+            sprintf('class="btn-micro btn-primary hasTooltip" target="_blank" title="%s"', JText::_('COM_OSMAP_XML_LINK_TOOLTIP', true))
         );
         ?>
-        <span class="icon-new-tab"></span>
     </span>
 
     <span class="osmap-link">
@@ -48,10 +47,9 @@ foreach ($languages as $language) :
             'link',
             $this->getLink($this->item, 'html', $langCode),
             JText::_('COM_OSMAP_HTML_LINK'),
-            sprintf('target="_blank" title="%s"', JText::_('COM_OSMAP_HTML_LINK_TOOLTIP', true))
+            sprintf('class="btn-micro btn-success hasTooltip" target="_blank" title="%s"', JText::_('COM_OSMAP_HTML_LINK_TOOLTIP', true))
         );
         ?>
-        <span class="icon-new-tab"></span>
     </span>
 
     <span class="osmap-link">
@@ -60,10 +58,9 @@ foreach ($languages as $language) :
             'link',
             $this->getLink($this->item, 'news', $langCode),
             JText::_('COM_OSMAP_NEWS_LINK'),
-            sprintf('target="_blank" title="%s"', JText::_('COM_OSMAP_NEWS_LINK_TOOLTIP', true))
+            sprintf('class="btn-micro btn-success hasTooltip" target="_blank" title="%s"', JText::_('COM_OSMAP_NEWS_LINK_TOOLTIP', true))
         );
         ?>
-        <span class="icon-new-tab"></span>
     </span>
 
     <span class="osmap-link">
@@ -72,10 +69,9 @@ foreach ($languages as $language) :
             'link',
             $this->getLink($this->item, 'images', $langCode),
             JText::_('COM_OSMAP_IMAGES_LINK'),
-            sprintf('target="_blank" title="%s"', JText::_('COM_OSMAP_IMAGES_LINK_TOOLTIP', true))
+            sprintf('class="btn-micro btn-success hasTooltip" target="_blank" title="%s"', JText::_('COM_OSMAP_IMAGES_LINK_TOOLTIP', true))
         );
         ?>
-        <span class="icon-new-tab"></span>
     </span>
     <br/>
     <?php


### PR DESCRIPTION
Hello! It seemed to me that this could be a good solution. If you do not like it - to hell with this PR :).

PR for `class="btn-micro btn-success hasTooltip"` (screenshot # 1), but you can still do this:

`class="btn-mini btn-success hasTooltip"` (screenshot # 2)

`class="btn-small btn-success hasTooltip"` (screenshot # 3)

![demo](https://user-images.githubusercontent.com/8440661/81478629-5e32f880-9227-11ea-886a-783dd4c03370.png)