### PR TITLE
Update Container.php

### DIFF
--- a/src/admin/library/Alledia/OSMap/View/Site/AbstractList.php
+++ b/src/admin/library/Alledia/OSMap/View/Site/AbstractList.php
@@ -278,7 +278,7 @@ class AbstractList extends \Alledia\Framework\Joomla\View\Site\AbstractList
         echo sprintf('<li class="%s" id="osmap-li-uid-%s">', $liClass, $sanitizedUID);
 
         // Some items are just separator, without a link. Do not print as link then
-        if (trim($item->rawLink) === '') {
+        if (trim($item->rawLink ?? '') === '') {
             $type = $item->type ?? 'separator';
             echo sprintf('<span class="osmap-item-%s">%s</span>', $type, htmlspecialchars($item->name));
 

--- a/src/admin/library/Pimple/Container.php
+++ b/src/admin/library/Pimple/Container.php
@@ -70,7 +70,7 @@ class Container implements \ArrayAccess
      * @param  mixed             $value The value of the parameter or a closure to define an object
      * @throws \RuntimeException Prevent override of a frozen service
      */
-    public function offsetSet($id, $value)
+    public function offsetSet($id, $value): void
     {
         if (isset($this->frozen[$id])) {
             throw new \RuntimeException(sprintf('Cannot override frozen service "%s".', $id));
@@ -89,7 +89,7 @@ class Container implements \ArrayAccess
      *
      * @throws \InvalidArgumentException if the identifier is not defined
      */
-    public function offsetGet($id)
+    public function offsetGet($id): mixed
     {
         if (!isset($this->keys[$id])) {
             throw new \InvalidArgumentException(sprintf('Identifier "%s" is not defined.', $id));
@@ -124,7 +124,7 @@ class Container implements \ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($id)
+    public function offsetExists($id): bool
     {
         return isset($this->keys[$id]);
     }
@@ -134,7 +134,7 @@ class Container implements \ArrayAccess
      *
      * @param string $id The unique identifier for the parameter or object
      */
-    public function offsetUnset($id)
+    public function offsetUnset($id): void
     {
         if (isset($this->keys[$id])) {
             if (is_object($this->values[$id])) {


### PR DESCRIPTION
Deprecated: Return type of Pimple\Container::offsetSet($id, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in ...\administrator\components\com_osmap\library\Pimple\Container.php on line 73

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in E:\xampp\htdocs\Joomla3\administrator\components\com_osmap\library\Alledia\OSMap\View\Site\AbstractList.php on line 281

PHP 8.1.6