### PR TITLE
Replace deprecated JDate by Date call to be J5 compatible

### DIFF
--- a/src/admin/library/Alledia/OSMap/Sitemap/Item.php
+++ b/src/admin/library/Alledia/OSMap/Sitemap/Item.php
@@ -600,7 +600,7 @@ class Item extends CMSObject
                 if ($this->modified < 0) {
                     $this->modified = null;
                 } else {
-                    $date           = new \JDate($this->modified);
+                    $date           = new Date($this->modified);
                     $this->modified = $date->toISO8601();
                 }
             }


### PR DESCRIPTION
Together with PR #166 , this one here will fix the issue that it needs the "Behaviour - Backward Compatibility" plugin of the CMS core needs to be enabled on Joomla 5 for using OSMap.

By review you can see for both PRs that the new methods "Date" and "Text" are already used just a few lines above the change on the same file.

So please apply this PR here and PR #166 to the next release of OSMap.