### PR TITLE
Fix error 500 "Unable to load application: site" in Joomla 5 backend when the "Behaviour - Backward Compatibility" plugin is disabled

### DIFF
--- a/src/admin/library/Installer/OSMap/Free/AbstractScript.php
+++ b/src/admin/library/Installer/OSMap/Free/AbstractScript.php
@@ -25,7 +25,6 @@
 namespace Alledia\Installer\OSMap\Free;
 
 use Alledia\Installer\OSMap\XmapConverter;
-use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
@@ -495,14 +494,13 @@ class AbstractScript extends \Alledia\Installer\AbstractScript
      */
     protected function fixXMLMenus()
     {
-        $db      = $this->dbo;
-        $siteApp = SiteApplication::getInstance('site');
+        $db = $this->dbo;
 
         $query = $db->getQuery(true)
             ->select('id, link')
             ->from('#__menu')
             ->where([
-                'client_id = ' . $siteApp->getClientId(),
+                'client_id = 0',
                 sprintf('link LIKE %s', $db->quote('%com_osmap%')),
                 sprintf('link LIKE %s', $db->quote('%view=xml%')),
                 sprintf('link NOT LIKE %s', $db->quote('%format=xml%')),

--- a/src/admin/models/sitemaps.php
+++ b/src/admin/models/sitemaps.php
@@ -23,7 +23,7 @@
  */
 
 use Alledia\OSMap\Factory;
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Utilities\ArrayHelper;
 
@@ -100,7 +100,7 @@ class OSMapModelSitemaps extends ListModel
     public function getItems()
     {
         if ($items = parent::getItems()) {
-            $siteApp = CMSApplication::getInstance('site');
+            $siteApp = Factory::getContainer()->get(SiteApplication::class);
             $menus   = $siteApp->getMenu()->getItems('component', 'com_osmap');
 
             foreach ($items as $item) {

--- a/src/admin/views/sitemaps/view.html.php
+++ b/src/admin/views/sitemaps/view.html.php
@@ -25,7 +25,7 @@
 use Alledia\OSMap\Factory;
 use Alledia\OSMap\Helper\General;
 use Alledia\OSMap\View\Admin\AbstractList;
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
@@ -141,7 +141,7 @@ class OSMapViewSitemaps extends AbstractList
             $query[$type] = 1;
         }
         if ($view == 'xml') {
-            $menu     = CMSApplication::getInstance('site')->getMenu()->getItem($menuId);
+            $menu     = Factory::getContainer()->get(SiteApplication::class)->getMenu()->getItem($menuId);
             $menuView = empty($menu->query['view']) ? null : $menu->query['view'];
 
             if ($view != $menuView) {


### PR DESCRIPTION
Together with PRs #166 and #168 , this PR here will make OSMap work on Joomla 5 with the "Behaviour - Backward Compatibility" plugin of the CMS core being disabled.

This PR here fixes the error 500 "Unable to load application: site" which you get when you have applied the other 2 PRs and you go to the component in backend.

In the "src/admin/models/sitemaps.php" and "src/admin/views/sitemaps/view.html.php" files, the deprecated call to `CMSApplication::getInstance('site')` is replaced by the site application fetched from the container.

In the "src/admin/library/Installer/OSMap/Free/AbstractScript.php" file there is no need to use the site application just for getting the client_id which is fix and hard-coded elsewhere in that file.