### PR TITLE
show hide/show help button in settings windows

### DIFF
--- a/src/admin/config.xml
+++ b/src/admin/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+    <inlinehelp button="show" />
     <fieldset name="basic"
               label="COM_OSMAP_FIELDSET_SITEMAP_SETTINGS_LABEL">
 


### PR DESCRIPTION
add options in config.xml to be able to show button for Showing/Hiding helps labels 