### PR TITLE
Static caching for Alledia\OSMap\Helper\General::getPluginsFromDatabase()

### DIFF
--- a/src/admin/library/Alledia/OSMap/Helper/General.php
+++ b/src/admin/library/Alledia/OSMap/Helper/General.php
@@ -126,28 +126,34 @@ abstract class General
      */
     public static function getPluginsFromDatabase(): array
     {
-        $db = Factory::getPimpleContainer()->db;
+        static $plugins;
+        
+        if ($plugins === null) {
+            $db = Factory::getPimpleContainer()->db;
 
-        // Get all the OSMap and XMap plugins. Get XMap plugins first
-        // then OSMap. Always respecting the ordering.
-        $query = $db->getQuery(true)
-            ->select([
-                'folder',
-                'params',
-                'element'
-            ])
-            ->from('#__extensions')
-            ->where('type = ' . $db->quote('plugin'))
-            ->where(
-                sprintf(
-                    'folder IN (%s)',
-                    join(',', $db->quote(['osmap', 'xmap']))
+            // Get all the OSMap and XMap plugins. Get XMap plugins first
+            // then OSMap. Always respecting the ordering.
+            $query = $db->getQuery(true)
+                ->select([
+                    'folder',
+                    'params',
+                    'element'
+                ])
+                ->from('#__extensions')
+                ->where('type = ' . $db->quote('plugin'))
+                ->where(
+                    sprintf(
+                        'folder IN (%s)',
+                        implode(',', $db->quote(['osmap', 'xmap']))
+                    )
                 )
-            )
-            ->where('enabled = 1')
-            ->order('folder DESC, ordering');
+                ->where('enabled = 1')
+                ->order('folder DESC, ordering');
 
-        return $db->setQuery($query)->loadObjectList();
+            $plugins = $db->setQuery($query)->loadObjectList();
+        }
+        
+        return $plugins;
     }
 
     /**


### PR DESCRIPTION
The method `Alledia\OSMap\Helper\General::getPluginsFromDatabase()` is called numerous times on sitemap generation and produces N+1 queries.

Static caching will help to have only one query.